### PR TITLE
Reduce inspect link length.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const link = generateLink({
   ],
 });
 
-// retrun inspect link `steam://rungame/730/76561202255233023/+csgo_econ_action_preview%2000180720DA03280638FBEE88F90340B2026213080310021D00000000250000803F2D00000000503D5A64`
+// return inspect link `steam://rungame/730/76561202255233023/+csgo_econ_action_preview%2000180720DA03280638FBEE88F90340B2026213080310021D00000000250000803F2D00000000503D5A64`
 
 const hex = generateHex({
   defindex: 7,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,13 +41,19 @@ const generateHex = ({
 }: CEconItemPreviewDataBlock): string => {
   const econ: CEconItemPreviewDataBlock = {
     ...props,
-    paintwear: floatToBytes(paintwear),
-    stickers: stickers.map((sticker) => ({
-      ...sticker,
-      offsetX: sticker.offsetX ?? 0,
-      offsetY: sticker.offsetY ?? 0,
-      rotations: sticker.rotation ?? 0,
-    })),
+    ...(paintwear !== 0.001 ? { paintwear: floatToBytes(paintwear) } : {}),
+    stickers: stickers.map((sticker) => {
+      const newSticker: any = {
+        slot: sticker.slot,
+        stickerId: sticker.stickerId,
+      };
+      if (sticker.wear && sticker.wear > 0) newSticker.wear = sticker.wear;
+      if (sticker.offsetX != 0) newSticker.offsetX = sticker.offsetX;
+      if (sticker.offsetY != 0) newSticker.offsetY = sticker.offsetY;
+      if (sticker.rotation != 0) newSticker.rotation = sticker.rotation;
+
+      return newSticker;
+    }),
   };
 
   let payload = CEconItemPreviewDataBlock.toBinary(econ);


### PR DESCRIPTION
If you have a link with 5 stickers with rotation, offsetX, offsetY, Rotation and wear, the link won't work the problem is with cs2 not with this program. If the link is too long they don't work. According to my testing if the link is < 295 characters long it will work.

Added code to not include some variables in hex generation if they are 0 or not defined.

paintwear , Sticker (wear,offsetX,offsetY, rotation) are only added if they have any value but 0.

This makes it possible to generate inspect links with more data and a shorter length.